### PR TITLE
implement HTTP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The script is written in Python 3 and [available on PyPI](https://pypi.org/proje
 
 ## Installation
 
-As the package is available on the Python package index, you can install it quickly into a Virtual Environment. First, you may need to create a folder for FHIR populator and an Virtual Environment (all commands are for Unix-based OS and may need tweaking on Windows):
+As the package is available on the Python package index, you can install it quickly into a Virtual Environment. First, you may need to create a folder for FHIR populator and a Virtual Environment (all commands are for Unix-based OS and may need tweaking on Windows):
 
 ```bash
 mkdir fhir-populator
@@ -87,7 +87,7 @@ To try out the program, you can spin up a FHIR server, such as [HAPI FHIR JPA Se
 python -m fhir_populator --endpoint http://localhost:8080/fhir --get-dependencies --package de.gecco
 ```
 
-As this example does not a specify a version of the `de.gecco` package, the latest version of the package will first be determined from the Simplifier API. You can also specify a version using the syntax `package@version`:
+As this example does not specify a version of the `de.gecco` package, the latest version of the package will first be determined from the Simplifier API. You can also specify a version using the syntax `package@version`:
 
 ```bash
 python -m fhir_populator --endpoint http://localhost:8080/fhir --get-dependencies --package de.gecco@1.0.3
@@ -105,8 +105,7 @@ The script is broken into multiple steps:
 
 1. All unversioned package references are converted to versioned references, by retrieving the package metadata from the NPM registry.
 2. The packages are downloaded as Tarballs into a temporary directory (under `/tmp` for Unix systems), and extracted there
-3. After each package is downloaded, the `package.json` is examined, and dependencies are added to the download queue, if desired.
-  * During this download, a dependency graph is built from the downloaded packages, to make sure that every package is uploaded after its dependencies
+3. After each package is downloaded, the `package.json` is examined, and dependencies are added to the download queue, if desired. During this download, a dependency graph is built from the downloaded packages, to make sure that every package is uploaded after its dependencies
 4. The packages are uploaded, file-by-file, to the FHIR server. This uses the topological sort of the directed dependency graph, to maintain consistency. Also, the files are uploaded in logical versions (e.g. `CodeSystem` before `ValueSet` before `StructureDefinition` before `Patient` etc.)
 5. If the FHIR server returns an error, the user is prompted interactively for input.
 6. When all resources are uploaded (or if the user aborts execution with *CTRL-C*), the temporary directory is recursively deleted.
@@ -119,10 +118,18 @@ There are a number of configuration options, which are (hopefully) mostly self-e
 * `--exclude-resource-type`: You can skip resource types, e.g. `--exclude-resource-type CodeSystem ValueSet ConceptMap`. This is not case-sensitive, the lower-case version of the resource type will be matched against the lower-case parameter list.
 * `--include-examples`: Examples in FHIR packages are great, but often not consistent across packages. For example, an `Observation` example might reference `Patient/example`, and this patient is nowhere to be found in the package, or its dependencies. Some FHIR servers (such as HAPI JPA Server) validate references on CREATE and return errors for missing references. Hence, examples (files in the `examples` folder of the package, as per the spec) are ignored by default.
 * `--non-interactive`: If provided, errors returned by the FHIR server will be ignored, and only a warning will be printed out.
-* `--only-put`: FHIR requires that IDs are present for all resources that are uploaded via HTTP PUT. Hence, if IDs are missing, a HTTP POST request is used by the script. This does not generate stable, or nice, IDs by default. You can provide this parameter to make the script generate IDs from the file name of the resource, which should be stable across reruns. This uses a "slugified" version of the filename without unsafe characters, and restricted to 64 characters, as per the specification.
+* `--only-put`: FHIR requires that IDs are present for all resources that are uploaded via HTTP PUT. Hence, if IDs are missing, an HTTP POST request is used by the script. This does not generate stable, or nice, IDs by default. You can provide this parameter to make the script generate IDs from the file name of the resource, which should be stable across reruns. This uses a "slugified" version of the filename without unsafe characters, and restricted to 64 characters, as per the specification.
 * `--registry-url`: While the script was only tested using the Simplifier registry, it should be compatible to other implementations of the [FHIR NPM Package Spec](https://wiki.hl7.org/FHIR_NPM_Package_Spec), which is implemented by the Simplifier software. You can provide the endpoint of an alternative registry hence.
 * `--rewrite-versions`: If provided, all `version` attributes of the resources will be rewritten to match the version in the `package.json`, to separate these definitions from previous versions. You will need to think about the versions numbers you use when communicating with others, who might not use the same versions - ⚠️  use with caution! ⚠️
 * `--versioned-ids`: To separate versions of the resources on the same FHIR server, you can override the IDs provided in the resources, by including the slugified version of the package in the ID. If combined with the `--only-put` switch, this will work the same, versioning existing IDs, and slugifying + versioning the filename of resources without IDs.
+
+## Proxy:
+
+* `--http-proxy`: URL of your HTTP proxy, may optionally include credentials (c.f. [the Requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#proxies))
+* `--https-proxy`: URL for HTTPS requests, if not provided, the HTTP proxy is used instead
+* `--proxy-for-fhir`: If provided, the proxy is also used for requests to your FHIR server
+* `--proxy-verify`: If provided, this public key (-chain) on your disk is used for validating the re-encrypted traffic to your proxy
+* `--proxy-for-fhir`: If provided, the proxy is also used for FHIR requests, not only for NPM requests
 
 ## Updating
 
@@ -141,7 +148,7 @@ If you want to customize the program, you should:
 3. Install the package locally, using `pip install .`
 4. Customize the script. Re-run step 3 if you change the script.
 5. `python -m fhir_populator`, as before.
-6. Create a issue and pull request in the GitHub Repo! We welcome contributions!
+6. Create an issue and pull request in the GitHub Repo! We welcome contributions!
 
 ## Changelog
 

--- a/src/fhir_populator/populator.py
+++ b/src/fhir_populator/populator.py
@@ -226,7 +226,8 @@ class Populator:
         os.mkdir(self.download_dir)
         self.extract_dir = os.path.join(self.temp_dir, "extract")
         os.mkdir(self.extract_dir)
-        self.fhir_requests_session = self.configure_session(use_auth=True, use_proxy=self.args.proxy_for_fhir)
+        self.fhir_requests_session = self.configure_session(configure_auth=True,
+                                                            configure_proxy=self.args.proxy_for_fhir)
 
     def __del__(self):
         if self.log is not None:
@@ -235,15 +236,15 @@ class Populator:
         if self.temp_dir is not None:
             shutil.rmtree(self.temp_dir)
 
-    def configure_session(self, use_auth: bool, use_proxy: bool) -> requests.Session:
+    def configure_session(self, configure_auth: bool, configure_proxy: bool) -> requests.Session:
         session = requests.Session()
-        if use_auth:
+        if configure_auth:
             if self.args.authorization_header is not None:
                 self.fhir_requests_session.headers.update({
                     "Authorization": self.args.authorization_header
                 })
                 self.log.debug(f"Using Authorization header: {self.args.authorization_header[:5]}...")
-        if use_proxy:
+        if configure_proxy:
             if self.args.has_proxy:
                 session.proxies = {
                     "http": self.args.http_proxy,
@@ -331,7 +332,7 @@ class Populator:
 
     def download_packages(self, packages: List[str]) -> nx.DiGraph:
         untar_folders = []
-        download_session = self.configure_session(use_auth=False, use_proxy=True)
+        download_session = self.configure_session(configure_auth=False, configure_proxy=True)
 
         get_deps = self.args.get_dependencies
         dependency_graph = nx.DiGraph()

--- a/src/fhir_populator/populator.py
+++ b/src/fhir_populator/populator.py
@@ -168,6 +168,11 @@ class PopulatorSettings:
     only_put: bool
     versioned_ids: bool
     registry_url: str
+    http_proxy: Optional[str]
+    https_proxy: Optional[str]
+    has_proxy: bool
+    proxy_verify: Optional[str]
+    proxy_for_fhir: bool
     only: List[str]
     log: logging.Logger
 
@@ -182,6 +187,11 @@ class PopulatorSettings:
         self.include_examples = args.include_examples
         self.rewrite_versions = args.rewrite_versions
         self.log_level = args.log_level
+        self.http_proxy = args.http_proxy
+        self.https_proxy = args.https_proxy
+        self.proxy_verify = args.proxy_verify
+        self.proxy_for_fhir = args.proxy_for_fhir
+        self.has_proxy = self.http_proxy is not None or self.https_proxy is not None
         self.exclude_resource_type = [a.lower() for a in args.exclude_resource_type] \
             if args.exclude_resource_type is not None \
             else []
@@ -216,12 +226,7 @@ class Populator:
         os.mkdir(self.download_dir)
         self.extract_dir = os.path.join(self.temp_dir, "extract")
         os.mkdir(self.extract_dir)
-        self.request_session = requests.Session()
-        if self.args.authorization_header is not None:
-            self.request_session.headers.update({
-                "Authorization": self.args.authorization_header
-            })
-            self.log.debug(f"Using Authorization header: {self.args.authorization_header[:10]}...")
+        self.fhir_requests_session = self.configure_session(use_auth=True, use_proxy=self.args.proxy_for_fhir)
 
     def __del__(self):
         if self.log is not None:
@@ -229,6 +234,26 @@ class Populator:
             self.log.debug(f"Deleting temp directory: {self.temp_dir}")
         if self.temp_dir is not None:
             shutil.rmtree(self.temp_dir)
+
+    def configure_session(self, use_auth: bool, use_proxy: bool) -> requests.Session:
+        session = requests.Session()
+        if use_auth:
+            if self.args.authorization_header is not None:
+                self.fhir_requests_session.headers.update({
+                    "Authorization": self.args.authorization_header
+                })
+                self.log.debug(f"Using Authorization header: {self.args.authorization_header[:5]}...")
+        if use_proxy:
+            if self.args.has_proxy:
+                session.proxies = {
+                    "http": self.args.http_proxy,
+                }
+                session.verify = self.args.proxy_verify
+                if self.args.https_proxy is not None:
+                    session.proxies["https"] = self.args.https_proxy
+                else:
+                    session.proxies["https"] = self.args.http_proxy
+        return session
 
     @staticmethod
     def parse_args() -> argparse.Namespace:
@@ -274,6 +299,20 @@ class Populator:
             "--versioned-ids", action="store_true",
             help="if provided, all resource IDs will be prefixed with the package version."
         )
+        parser.add_argument("--http-proxy", help="A HTTP proxy to use when requesting FHIR packages")
+        parser.add_argument("--https-proxy", help="A HTTPS proxy to use when requesting FHIR packages; if null and "
+                                                  "http-proxy is not none, the HTTP proxy is used.")
+        parser.add_argument("--proxy-verify",
+                            help="Path to a openSSL certificate (chain) for trusting HTTPS connections to your proxy, "
+                                 "HTTPs connections without this will likely not work!")
+        parser.add_argument("--proxy-for-fhir", action="store_true")
+        parser.add_argument(
+            "--package", nargs="+", type=str, dest="packages",
+            help="Specification for the package to download and push to the FHIR server. " +
+                 "You can specify more than one package. " +
+                 "Use the syntax 'package@version', or leave out the version to use the latest package " +
+                 "available on the registry."
+        )
         group = parser.add_mutually_exclusive_group()
         group.add_argument(
             "--exclude-resource-type", type=str, nargs="*",
@@ -288,17 +327,12 @@ class Populator:
             "--registry-url", type=str, default="https://packages.simplifier.net",
             help="The FHIR registry url, Simplifier by default"
         )
-        parser.add_argument(
-            "--package", nargs="+", type=str, dest="packages",
-            help="Specification for the package to download and push to the FHIR server. " +
-                 "You can specify more than one package. " +
-                 "Use the syntax 'package@version', or leave out the version to use the latest package " +
-                 "available on the registry."
-        )
         return parser.parse_args()
 
     def download_packages(self, packages: List[str]) -> nx.DiGraph:
         untar_folders = []
+        download_session = self.configure_session(use_auth=False, use_proxy=True)
+
         get_deps = self.args.get_dependencies
         dependency_graph = nx.DiGraph()
         packages_to_download = list(packages)
@@ -309,7 +343,7 @@ class Populator:
                 self.log.debug(f"Package {package} is already downloaded.")
                 continue
             self.log.info(f"Downloading package with spec {package}")
-            package_path = self.download_untar_package(package_name=package)
+            package_path = self.download_untar_package(package_name=package, session=download_session)
             untar_folders.append(package_path)
             dependency_graph.add_node(package, path=package_path)
             if get_deps:
@@ -325,10 +359,11 @@ class Populator:
             self.log.debug(f" - {node}")
         return dependency_graph
 
-    def download_untar_package(self, package_name: str) -> str:
+    def download_untar_package(self, package_name: str, session: requests.Session) -> str:
         """
         download a package from the registry
         :param package_name:
+        :param session:
         :return:
         """
         if '@' in package_name:
@@ -344,7 +379,7 @@ class Populator:
             method="GET",
             url=request_url
         ).prepare()
-        download_response = self.request_session.send(download_request, stream=True)
+        download_response = session.send(download_request, stream=True)
         with open(download_path, "wb") as download_fs:
             for chunk in download_response.iter_content(chunk_size=8192):
                 download_fs.write(chunk)
@@ -381,7 +416,7 @@ class Populator:
             method="GET",
             url=lookup_url
         ).prepare()
-        response = self.request_session.send(lookup_request)
+        response = self.fhir_requests_session.send(lookup_request)
         versions = [v["version"] for v in response.json()["versions"].values()]
         self.log.debug(f"Available versions for '{package_name}': {versions}")
         last_version = versions[-1]
@@ -514,7 +549,7 @@ class Populator:
                     data=payload
                 ).prepare()
                 self.log.info(f"uploading to {upload_url} (content type: {content_type})")
-                upload_result = self.request_session.send(upload_request)
+                upload_result = self.fhir_requests_session.send(upload_request)
                 if 200 <= upload_result.status_code < 300:
                     self.log.debug(f"uploaded {fhir_file.resource_type} with status {upload_result.status_code}")
                 else:


### PR DESCRIPTION
adds 4 new CMD line switches:
- `--http-proxy` (also used for https if not explicitly set)
- `--https-proxy`
- `--proxy-verify` (path to a certificate chain for trusting the proxy)
- `--proxy-for-fhir` (if provided, the proxy is also used for FHIR requests)